### PR TITLE
changing preCreateChatMessage hook to chatMessage

### DIFF
--- a/src/scripts/arc.ts
+++ b/src/scripts/arc.ts
@@ -68,8 +68,8 @@ Hooks.once('canvasReady', async () => {
     game.readyCheckHud = new ReadyCheckHud();
   }
 
-  Hooks.on('preCreateChatMessage', (msg, data, options) => {
-    if (data.content.toLowerCase().trim() === AFK_READY_CHECK_CHAT_COMMAND && isGM()) {
+  Hooks.on('chatMessage', (chatlog, content, options) => {
+    if (content.toLowerCase().trim() === AFK_READY_CHECK_CHAT_COMMAND && isGM()) {
       log('ready check chat command intercepted!');
       socket.emit(SOCKET_NAME, { type: ArcSocketEventType.readyCheck, data: {} });
       setAllPlayerStatusesToUnknown();
@@ -77,13 +77,13 @@ Hooks.once('canvasReady', async () => {
       AudioHelper.play({ src: 'modules/afk-ready-check/sounds/ready-check.ogg', volume: 0.8, autoplay: true, loop: false }, true);
       return false;
     }
-    if (data.content.toLowerCase().trim() === AFK_CHAT_COMMAND) {
+    if (content.toLowerCase().trim() === AFK_CHAT_COMMAND) {
       log('afk chat command intercepted!');
       socket.emit(SOCKET_NAME, { type: ArcSocketEventType.statusReport, data: { name: game.user.name, status: AfkStatus.afk } });
       renderPlayerAfkStatus(game.user.name, AfkStatus.afk);
       return false;
     }
-    if (data.content.toLowerCase().trim() === READY_CHAT_COMMAND) {
+    if (content.toLowerCase().trim() === READY_CHAT_COMMAND) {
       log('ready check chat command intercepted!');
       socket.emit(SOCKET_NAME, { type: ArcSocketEventType.statusReport, data: { name: game.user.name, status: AfkStatus.notAfk } });
       renderPlayerAfkStatus(game.user.name, AfkStatus.notAfk);


### PR DESCRIPTION
I have installed the module , but was getting an error saying "/readycheck is not a valid chat command". <br>
I looked at the source code of the module and saw that it uses "preCreateChatMessage" hook <br>
Then I looked at the hooks that are firing and the only one was "chatMessage" <br>
If I understand correctly, foundry attempts to parse the message before "preCreateChatMessage" is fired, and fails <br>
I am not sure how the module worked in testing, but here's an easy fix.